### PR TITLE
Add dockerfile for bsc geth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM frolvlad/alpine-glibc
-RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.0.6/geth_linux
-RUN chmod 744 geth_linux
-RUN mv geth_linux /usr/local/bin/geth
-ENTRYPOINT ["/usr/local/bin/geth"]
+FROM debian:stable-slim
+
+RUN apt-get update -y && apt-get install wget -y
+RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.0.6/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+
+ENTRYPOINT ["geth"]


### PR DESCRIPTION
1. BSC doesn't have a docker image. See: https://github.com/binance-chain/bsc/issues/88
2. Basic alpine doesn't work as geth_linux will also throw a 'file not found'-like of error. This is due to glibc

Thus, this PR.