### PR TITLE
Add curl to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-RUN apt-get update -y && apt-get install wget -y
+RUN apt-get update -y && apt-get install wget curl -y
 RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.0.6/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
This adds curl to assist with our liveness probe.

We will need to delete tag 1.06 from dockerhub and github and redo them again.