### PR TITLE
Update bsc docker to 1.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-RUN apt-get update -y && apt-get install wget curl -y
-RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.0.6/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
+RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.0.7/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
As topic.

Once again, the reason for this docker image is because binance doesn't have a docker hub for their images yet.
Once they have their own repo, we can delete this repo.