### PR TITLE
bsc-hotfix-prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.1.18/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.1.18_hf/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
Our multi-geth dashboard for bsc was broken after we upgraded to v1.18, this release is for the Hotfix: https://chainstackhq.slack.com/archives/C02373PR1MY/p1669887941430529