### PR TITLE
remove --no-check-certificate and clear apt cache after installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.1.19/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y && rm -rf /var/lib/apt/lists/*
+RUN wget -O /usr/local/bin/geth https://github.com/binance-chain/bsc/releases/download/v1.1.19/geth_linux && chmod 744 /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
This PR: 
* removes `--no-check-certificate ` while downloading geth 
* clears apt cache after installation