### PR TITLE
feature/OPS-2923 - Releases BSC v1.2.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/binance-chain/bsc/releases/download/v1.3.3/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.2.15/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
Needed for [HF coming up tomorrow](https://github.com/bnb-chain/bsc/releases/tag/v1.3.4).

We have to support both [v1.2.15](https://github.com/bnb-chain/bsc/releases/tag/v1.2.15) and [v1.3.4](https://github.com/bnb-chain/bsc/releases/tag/v1.3.4), because our fleet is not entirely migrated.