### PR TITLE
BSC image upgrade 1.5.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.10/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.11/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
[OPS-4897](https://chainstack.myjetbrains.com/youtrack/issue/OPS-4897) Bsc v1.5.11 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application to use version 1.5.11 of the BNB Chain binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->