### PR TITLE
BSC testnet image upgrade v1.5.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.12/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.13/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
[OPS-5072](https://chainstack.myjetbrains.com/youtrack/issue/OPS-5072) Bsc v1.5.13 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application to use version 1.5.13 of the geth_linux binary from BNB Chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->