### PR TITLE
BSC image upgrade v1.5.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.13/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.5.16/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
New release: 
https://github.com/bnb-chain/bsc/releases/tag/v1.5.16