### PR TITLE
upgrade 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
 RUN apt-get update -y && apt-get install wget curl procps net-tools htop -y
-RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.6.6/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
+RUN wget --no-check-certificate https://github.com/bnb-chain/bsc/releases/download/v1.7.1/geth_linux && chmod 744 geth_linux && mv geth_linux /usr/local/bin/geth
 
 ENTRYPOINT ["geth"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated geth binary in Docker image from v1.6.6 to v1.7.1. The upgrade preserves all existing deployment compatibility and functionality while incorporating improvements and bug fixes available in the newer geth release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->